### PR TITLE
Fix multiple definition errors

### DIFF
--- a/barkeep/barkeep.h
+++ b/barkeep/barkeep.h
@@ -365,7 +365,7 @@ struct AnimationConfig {
   bool show = true; ///< show the animation immediately after construction
 };
 
-Duration as_duration(std::variant<Duration, double> interval) {
+inline Duration as_duration(std::variant<Duration, double> interval) {
   if (std::holds_alternative<Duration>(interval)) {
     return std::get<Duration>(interval);
   } else {
@@ -421,7 +421,7 @@ class AnimationDisplay : public BaseDisplay {
 
 /// Convenience factory function to create a shared_ptr to AnimationDisplay.
 /// Prefer this to constructing AnimationDisplay directly.
-auto Animation(const AnimationConfig& cfg = {}) {
+inline auto Animation(const AnimationConfig& cfg = {}) {
   return std::make_shared<AnimationDisplay>(cfg);
 }
 
@@ -468,7 +468,7 @@ class StatusDisplay : public AnimationDisplay {
 
 /// Convenience factory function to create a shared_ptr to StatusDisplay.
 /// Prefer this to constructing StatusDisplay directly.
-auto Status(const AnimationConfig& cfg = {}) {
+inline auto Status(const AnimationConfig& cfg = {}) {
   return std::make_shared<StatusDisplay>(cfg);
 }
 
@@ -1032,13 +1032,13 @@ class CompositeDisplay : public BaseDisplay {
 
 /// Convenience factory function to create a shared_ptr to CompositeDisplay.
 /// Prefer this to constructing CompositeDisplay directly.
-auto Composite(const std::vector<std::shared_ptr<BaseDisplay>>& displays,
+inline auto Composite(const std::vector<std::shared_ptr<BaseDisplay>>& displays,
                std::string delim = " ") {
   return std::make_shared<CompositeDisplay>(displays, std::move(delim));
 }
 
 /// Pipe operator can be used to combine two displays into a Composite.
-auto operator|(std::shared_ptr<BaseDisplay> left,
+inline auto operator|(std::shared_ptr<BaseDisplay> left,
                std::shared_ptr<BaseDisplay> right) {
   return std::make_shared<CompositeDisplay>(
       std::vector{std::move(left), std::move(right)});


### PR DESCRIPTION
Fixes #93 by adding missing `inline` keywords.